### PR TITLE
add : API, Family 회원별로 수정된 가족정보 독립적으로 구성

### DIFF
--- a/api/src/main/java/com/yapp/api/domain/family/persistence/entity/Family.java
+++ b/api/src/main/java/com/yapp/api/domain/family/persistence/entity/Family.java
@@ -17,6 +17,7 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 import com.yapp.api.domain.common.BaseEntity;
+import com.yapp.api.domain.family.persistence.entity.element.FamilyInfo;
 import com.yapp.api.domain.user.persistence.entity.User;
 
 import lombok.AllArgsConstructor;
@@ -35,11 +36,17 @@ public class Family extends BaseEntity {
 
 	private String name;
 	private String motto;
+	private String imageLink;
+
+	@Embedded
+	@Getter(PRIVATE)
+	private FamilyInfos familyInfos = new FamilyInfos();
 
 	@OneToOne(fetch = LAZY)
 	private User owner;
 
 	@Embedded
+	@Getter(PRIVATE)
 	private Members members = new Members();
 
 	@Builder
@@ -54,6 +61,10 @@ public class Family extends BaseEntity {
 		return members.getCount();
 	}
 
+	public void addFamilyInfo(FamilyInfo familyInfo) {
+		this.familyInfos.add(this, familyInfo);
+	}
+
 	@Embeddable
 	@Getter
 	@NoArgsConstructor(access = PROTECTED)
@@ -62,12 +73,26 @@ public class Family extends BaseEntity {
 		@OneToMany(mappedBy = "family", fetch = LAZY)
 		private Set<User> members = new HashSet<>();
 
-		public void add(User user) {
+		void add(User user) {
 			members.add(user);
 		}
 
-		public int getCount() {
+		int getCount() {
 			return members.size();
+		}
+	}
+
+	@Embeddable
+	@Getter
+	@NoArgsConstructor(access = PROTECTED)
+	@AllArgsConstructor(access = PRIVATE)
+	private class FamilyInfos {
+		@OneToMany(mappedBy = "family", fetch = LAZY)
+		private Set<FamilyInfo> familyInfos = new HashSet<>();
+
+		public void add(Family family, FamilyInfo familyInfo) {
+			familyInfo.setFamily(family);
+			familyInfos.add(familyInfo);
 		}
 	}
 }

--- a/api/src/main/java/com/yapp/api/domain/family/persistence/entity/element/FamilyInfo.java
+++ b/api/src/main/java/com/yapp/api/domain/family/persistence/entity/element/FamilyInfo.java
@@ -1,0 +1,44 @@
+package com.yapp.api.domain.family.persistence.entity.element;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import com.yapp.api.domain.family.persistence.entity.Family;
+import com.yapp.api.domain.user.persistence.entity.User;
+
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class FamilyInfo {
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	private String name;
+	private String motto;
+	private String imageLink;
+
+	@ManyToOne(fetch = LAZY)
+	private Family family;
+
+	@ManyToOne(fetch = LAZY)
+	private User user;
+
+	public FamilyInfo(User user, String name, String motto, String imageLink) {
+		this.user = user;
+		this.name = name;
+		this.motto = motto;
+		this.imageLink = imageLink;
+	}
+
+	public void setFamily(Family family) {
+		this.family = family;
+	}
+}


### PR DESCRIPTION
## content
- #6

가족 정보가 수정되면, 수정한 회원만 독립적으로 수정된 정보를 조회할 수 있다. 
(즉, 다른 가족 구성원들이 별도의 수정이 없다면 기본 가족 정보로 조회되어지고, 다른 사람이 수정한 내역은 본인에게 반영되어지지 않는다.)

## reference
